### PR TITLE
Implements parallel leaf hashing in `process_sorted_pairs_to_leaves`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Generate reverse mutations set on applying of mutations set, implemented serialization of `MutationsSet` (#355).
 - Added parallel implementation of `Smt::compute_mutations` with better performance (#365).
+- Implemented parallel leaf hashing in `SparseMerkleTree::process_sorted_pairs_to_leaves`.
 
 ## 0.13.0 (2024-11-24)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ name = "store"
 harness = false
 
 [features]
-concurrent = ["dep:rayon"]
+concurrent = ["dep:rayon", "hashbrown?/rayon"]
 default = ["std", "concurrent"]
 executable = ["dep:clap", "dep:rand-utils", "std"]
 smt_hashmaps = ["dep:hashbrown"]

--- a/src/merkle/smt/mod.rs
+++ b/src/merkle/smt/mod.rs
@@ -754,9 +754,12 @@ pub(crate) trait SparseMerkleTree<const DEPTH: u8> {
         }
 
         // Compute the leaves from the nodes concurrently
-        let mut accumulated_leaves: Vec<SubtreeLeaf> = accumulator.nodes.clone().into_par_iter().map(|(col, leaf)| {
-            SubtreeLeaf { col, hash: Self::hash_leaf(&leaf) }
-        }).collect();
+        let mut accumulated_leaves: Vec<SubtreeLeaf> = accumulator
+            .nodes
+            .clone()
+            .into_par_iter()
+            .map(|(col, leaf)| SubtreeLeaf { col, hash: Self::hash_leaf(&leaf) })
+            .collect();
 
         // Sort the leaves by column
         accumulated_leaves.sort_by_key(|leaf| leaf.col);

--- a/src/merkle/smt/tests.rs
+++ b/src/merkle/smt/tests.rs
@@ -23,6 +23,7 @@ fn smtleaf_to_subtree_leaf(leaf: &SmtLeaf) -> SubtreeLeaf {
 }
 
 #[test]
+#[cfg(feature = "concurrent")]
 fn test_sorted_pairs_to_leaves() {
     let entries: Vec<(RpoDigest, Word)> = vec![
         // Subtree 0.
@@ -148,6 +149,7 @@ fn generate_updates(entries: Vec<(RpoDigest, Word)>, updates: usize) -> Vec<(Rpo
 }
 
 #[test]
+#[cfg(feature = "concurrent")]
 fn test_single_subtree() {
     // A single subtree's worth of leaves.
     const PAIR_COUNT: u64 = COLS_PER_SUBTREE;
@@ -187,6 +189,7 @@ fn test_single_subtree() {
 // subtree into computing another. In other words, test that `build_subtree()` is correctly
 // composable.
 #[test]
+#[cfg(feature = "concurrent")]
 fn test_two_subtrees() {
     // Two subtrees' worth of leaves.
     const PAIR_COUNT: u64 = COLS_PER_SUBTREE * 2;
@@ -244,6 +247,7 @@ fn test_two_subtrees() {
 }
 
 #[test]
+#[cfg(feature = "concurrent")]
 fn test_singlethreaded_subtrees() {
     const PAIR_COUNT: u64 = COLS_PER_SUBTREE * 64;
 
@@ -455,6 +459,7 @@ fn test_with_entries_parallel() {
 }
 
 #[test]
+#[cfg(feature = "concurrent")]
 fn test_singlethreaded_subtree_mutations() {
     const PAIR_COUNT: u64 = COLS_PER_SUBTREE * 64;
 


### PR DESCRIPTION
This PR introduces an optimization to `process_sorted_pairs_to_leaves` by parallelizing the leaf hashing process, which was previously executed sequentially.

For a 10M-entry tree construction on a 128-thread CPU, the function runtime was reduced from ~90 to ~6 secs.