### PR TITLE
refactor: eliminate code duplication in RandomCoin deserialization

### DIFF
--- a/miden-crypto/src/rand/rpo.rs
+++ b/miden-crypto/src/rand/rpo.rs
@@ -222,20 +222,12 @@ impl Serializable for RpoRandomCoin {
 
 impl Deserializable for RpoRandomCoin {
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
-        let state = [
-            Felt::read_from(source)?,
-            Felt::read_from(source)?,
-            Felt::read_from(source)?,
-            Felt::read_from(source)?,
-            Felt::read_from(source)?,
-            Felt::read_from(source)?,
-            Felt::read_from(source)?,
-            Felt::read_from(source)?,
-            Felt::read_from(source)?,
-            Felt::read_from(source)?,
-            Felt::read_from(source)?,
-            Felt::read_from(source)?,
-        ];
+        let state_vec = crate::utils::read_felt_array(source, STATE_WIDTH)?;
+        let state: [Felt; STATE_WIDTH] = state_vec
+            .try_into()
+            .map_err(|_| DeserializationError::InvalidValue(
+                format!("invalid state array length, expected {STATE_WIDTH}"),
+            ))?;
         let current = source.read_u8()? as usize;
         if !(RATE_START..RATE_END).contains(&current) {
             return Err(DeserializationError::InvalidValue(

--- a/miden-crypto/src/rand/rpx.rs
+++ b/miden-crypto/src/rand/rpx.rs
@@ -222,20 +222,12 @@ impl Serializable for RpxRandomCoin {
 
 impl Deserializable for RpxRandomCoin {
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
-        let state = [
-            Felt::read_from(source)?,
-            Felt::read_from(source)?,
-            Felt::read_from(source)?,
-            Felt::read_from(source)?,
-            Felt::read_from(source)?,
-            Felt::read_from(source)?,
-            Felt::read_from(source)?,
-            Felt::read_from(source)?,
-            Felt::read_from(source)?,
-            Felt::read_from(source)?,
-            Felt::read_from(source)?,
-            Felt::read_from(source)?,
-        ];
+        let state_vec = crate::utils::read_felt_array(source, STATE_WIDTH)?;
+        let state: [Felt; STATE_WIDTH] = state_vec
+            .try_into()
+            .map_err(|_| DeserializationError::InvalidValue(
+                format!("invalid state array length, expected {STATE_WIDTH}"),
+            ))?;
         let current = source.read_u8()? as usize;
         if !(RATE_START..RATE_END).contains(&current) {
             return Err(DeserializationError::InvalidValue(

--- a/miden-crypto/src/utils/mod.rs
+++ b/miden-crypto/src/utils/mod.rs
@@ -266,3 +266,25 @@ pub fn bytes_to_packed_u32_elements(bytes: &[u8]) -> Vec<Felt> {
         })
         .collect()
 }
+
+/// Deserializes an array of `Felt` elements from a byte reader.
+///
+/// # Arguments
+/// * `source` - The byte reader to deserialize from
+/// * `len` - The length of the array to deserialize
+///
+/// # Returns
+/// `Result<Vec<Felt>, DeserializationError>` - Vector of deserialized `Felt` elements
+///
+/// # Errors
+/// Returns `DeserializationError` if deserialization fails for any element
+pub fn read_felt_array<R: ByteReader>(
+    source: &mut R,
+    len: usize,
+) -> Result<Vec<Felt>, DeserializationError> {
+    let mut result = Vec::with_capacity(len);
+    for _ in 0..len {
+        result.push(Felt::read_from(source)?);
+    }
+    Ok(result)
+}


### PR DESCRIPTION
## Describe your changes
Hello! This PR refactors the deserialization logic for `RpoRandomCoin` and `RpxRandomCoin` by extracting common functionality into a reusable utility function, eliminating code duplication and improving maintainability.
  - New utility function `read_felt_array` in `utils/mod.rs` for deserializing arrays of `Felt` elements
  - Provides a generic helper for reading arrays of `Felt` from a `ByteReader`

## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- Documentation/comments updated according to changes.
